### PR TITLE
pysnmp 7.1.15

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/pysmi-feedstock/pr1/3013518

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/pysmi-feedstock/pr1/3013518

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.4.12" %}
+{% set version = "7.1.15" %}
 
 package:
   name: pysnmp
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pysnmp/pysnmp-{{ version }}.tar.gz
-  sha256: 0c3dbef2f958caca96071fe5c19de43e9c1b0484ab02a0cf08b190bcee768ba9
+  sha256: f624f2fab9503431f6514ad388b32aa657b36da59d2bc9b6059786db7d9f6257
   patches:
     - setuptools_version.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,49 +7,32 @@ package:
 source:
   url: https://pypi.io/packages/source/p/pysnmp/pysnmp-{{ version }}.tar.gz
   sha256: f624f2fab9503431f6514ad388b32aa657b36da59d2bc9b6059786db7d9f6257
-  patches:
-    - setuptools_version.patch
 
 build:
-  number: 1
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
-  build:
-    - patch     # [not win]
-    - m2-patch  # [win]
   host:
     - python
+    - poetry-core >=1.0.0
     - pip
   run:
     - python
-    - pyasn1 >=0.2.3
-    - pysmi
-    - pycryptodomex
-    - twisted
+    - pyasn1 >=0.4.8,!=0.5.0
+    - pysmi >=1.3.0,<2.0.0
 
 test:
+  requires:
+    - python
   imports:
     - pysnmp
     - pysnmp.carrier
     - pysnmp.carrier.asyncio
     - pysnmp.carrier.asyncio.dgram
-    - pysnmp.carrier.asyncore
-    - pysnmp.carrier.asyncore.dgram
-    - pysnmp.carrier.asynsock
-    - pysnmp.carrier.asynsock.dgram
-    - pysnmp.carrier.twisted
-    - pysnmp.carrier.twisted.dgram
     - pysnmp.entity
     - pysnmp.entity.rfc3413
-    - pysnmp.entity.rfc3413.oneliner
-    - pysnmp.hlapi
     - pysnmp.hlapi.asyncio
-    - pysnmp.hlapi.asyncore
-    - pysnmp.hlapi.asyncore.sync
-    - pysnmp.hlapi.asyncore.sync.compat
-    - pysnmp.hlapi.twisted
     - pysnmp.proto
     - pysnmp.proto.acmod
     - pysnmp.proto.api

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ test:
     - pip check
 
 about:
-  home: https://snmplabs.com/pysnmp
+  home: https://www.pysnmp.com/pysnmp/
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE.rst
@@ -66,8 +66,8 @@ about:
     features fully-functional SNMP engine capable to act in Agent/Manager/Proxy
     roles, talking SNMP v1/v2c/v3 protocol versions over IPv4/IPv6 and other
     network transports.
-  doc_url: https://pysnmp.sourceforge.net/docs/tutorial.html
-  dev_url: https://github.com/etingof/pysnmp
+  doc_url: https://docs.lextudio.com/pysnmp/
+  dev_url: https://github.com/lextudio/pysnmp
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
 test:
   requires:
     - python
+    - pip
   imports:
     - pysnmp
     - pysnmp.carrier
@@ -51,9 +52,11 @@ test:
     - pysnmp.smi
     - pysnmp.smi.mibs
     - pysnmp.smi.mibs.instances
+  commands:
+    - pip check
 
 about:
-  home: http://snmplabs.com/pysnmp
+  home: https://snmplabs.com/pysnmp
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE.rst
@@ -63,8 +66,7 @@ about:
     features fully-functional SNMP engine capable to act in Agent/Manager/Proxy
     roles, talking SNMP v1/v2c/v3 protocol versions over IPv4/IPv6 and other
     network transports.
-  doc_url: http://pysnmp.sourceforge.net/docs/tutorial.html
-  doc_source_url: https://github.com/etingof/pysnmp/tree/master/docs/source/docs
+  doc_url: https://pysnmp.sourceforge.net/docs/tutorial.html
   dev_url: https://github.com/etingof/pysnmp
 
 extra:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,1 +1,0 @@
-from pysnmp.entity.rfc3413.oneliner import cmdgen


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6089](https://anaconda.atlassian.net/browse/PKG-6089)
- [Upstream repository](https://github.com/etingof/pysnmp)

### Explanation of changes:

- Update version
- Remove run_test.py
- Update test import and add pip check
- linter fixes


[PKG-6089]: https://anaconda.atlassian.net/browse/PKG-6089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ