### PR TITLE
pysnmp 7.1.22 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,31 +1,31 @@
-{% set version = "7.1.15" %}
+{% set name = "pysnmp" %}
+{% set version = "7.1.22" %}
 
 package:
-  name: pysnmp
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pysnmp/pysnmp-{{ version }}.tar.gz
-  sha256: f624f2fab9503431f6514ad388b32aa657b36da59d2bc9b6059786db7d9f6257
+  url: https://github.com/lextudio/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 6bda6ac80d65fac77fd40f259405fc066b4218a616bf16b4345b3e98ca70feeb
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
+  skip: true  # [py<310]
 
 requirements:
   host:
-    - python
-    - poetry-core >=1.0.0
     - pip
+    - python
+    - flit-core>=3.9.0
   run:
     - python
     - pyasn1 >=0.4.8,!=0.5.0
-    - pysmi >=1.3.0,<2.0.0
 
+# Tests disabled until a new version of pysmi is released.
+# Latest pysmi in main 1.5.9, needs version >=1.6.1
 test:
-  requires:
-    - python
-    - pip
   imports:
     - pysnmp
     - pysnmp.carrier
@@ -54,9 +54,11 @@ test:
     - pysnmp.smi.mibs.instances
   commands:
     - pip check
+  requires:
+    - pip
 
 about:
-  home: https://www.pysnmp.com/pysnmp/
+  home: https://www.pysnmp.com/pysnmp
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE.rst
@@ -66,7 +68,7 @@ about:
     features fully-functional SNMP engine capable to act in Agent/Manager/Proxy
     roles, talking SNMP v1/v2c/v3 protocol versions over IPv4/IPv6 and other
     network transports.
-  doc_url: https://docs.lextudio.com/pysnmp/
+  doc_url: https://docs.lextudio.com/pysnmp
   dev_url: https://github.com/lextudio/pysnmp
 
 extra:


### PR DESCRIPTION
pysnmp 7.1.22 

**Destination channel:** Defaults

### Links

- [PKG-10816]
- dev_url:        https://github.com/lextudio/pysnmp/tree/v7.1.22
- conda_forge:    https://github.com/conda-forge/pysnmp-feedstock
- pypi:           https://pypi.org/project/pysnmp/7.1.22
- pypi inspector: https://inspector.pypi.io/project/pysnmp/7.1.22

### Explanation of changes:

- new version number


[PKG-10816]: https://anaconda.atlassian.net/browse/PKG-10816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ